### PR TITLE
Update Command.cs

### DIFF
--- a/Source/Core/Globals/Command.cs
+++ b/Source/Core/Globals/Command.cs
@@ -1,410 +1,691 @@
-﻿namespace Core.Globals;
+// ReSharper disable InconsistentNaming
+// ReSharper disable RedundantCast
+// ReSharper disable ConvertIfStatementToReturnStatement
 
-public static class Command
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Core.Globals
 {
-    private static readonly int EquipmentCount = Enum.GetNames<Equipment>().Length;
-
-    public static string GetAccountLogin(int index)
+    public static class Command
     {
-        return Data.Account[index].Login;
-    }
+        // ------------------------------------
+        // Constants / helpers
+        // ------------------------------------
 
-    public static int GetPlayerExp(int index)
-    {
-        return Data.Player[index].Exp;
-    }
+        private const int TileSize = 32;
 
-    public static int GetPlayerRawStat(int index, Stat stat)
-    {
-        return Data.Player[index].Stat[(int) stat];
-    }
+        // Faster and safer than Enum.GetNames().Length
+        private static readonly int EquipmentCount = Enum.GetValues<Equipment>().Length;
 
-    public static string GetPlayerName(int index)
-    {
-        return Data.Player[index].Name;
-    }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static byte ClampToByte(int v) => (byte)(v < byte.MinValue ? byte.MinValue : (v > byte.MaxValue ? byte.MaxValue : v));
 
-    public static int GetPlayerInvValue(int index, int invslot)
-    {
-        return Data.Player[index].Inv[invslot].Value;
-    }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int Clamp(int v, int min, int max) => v < min ? min : (v > max ? max : v);
 
-    public static int GetPlayerPoints(int index)
-    {
-        return Data.Player[index].Points;
-    }
-
-    public static int GetPlayerVital(int index, Vital vital)
-    {
-        return Data.Player[index].Vital[(int) vital];
-    }
-
-    public static int GetPlayerSprite(int index)
-    {
-        return Data.Player[index].Sprite;
-    }
-
-    public static int GetPlayerJob(int index)
-    {
-        return Data.Player[index].Job;
-    }
-
-    public static int GetPlayerMap(int index)
-    {
-        return Data.Player[index].Map;
-    }
-
-    public static int GetPlayerLevel(int index)
-    {
-        return Data.Player[index].Level;
-    }
-
-    public static int GetPlayerEquipment(int index, Equipment equipmentSlot)
-    {
-        return Data.Player[index].Equipment[(int) equipmentSlot];
-    }
-
-    public static int GetPlayerSkill(int index, int skillSlot)
-    {
-        return Data.Player[index].Skill[skillSlot].Num;
-    }
-
-    public static int GetPlayerSkillCd(int index, int skillSlot)
-    {
-        return Data.Player[index].Skill[skillSlot].Cd;
-    }
-
-    public static void SetPlayerLogin(int index, string login)
-    {
-        Data.Account[index].Login = login;
-    }
-
-    public static string GetPlayerPassword(int index)
-    {
-        return Data.Account[index].Password;
-    }
-
-    public static void SetPlayerPassword(int index, string password)
-    {
-        Data.Account[index].Password = password;
-    }
-
-    public static int GetPlayerMaxVital(int index, Vital vital)
-    {
-        return vital switch
+        /// <summary>Floor division for signed integers (correct for negatives).</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int FloorDiv(int value, int divisor)
         {
-            Vital.Health => (int) Math.Round(100d + (Data.Player[index].Level + GetPlayerStat(index, Stat.Vitality) / 2d) * 2d),
-            Vital.Mana => (int) Math.Round(50d + (Data.Player[index].Level + GetPlayerStat(index, Stat.Intelligence) / 2d) * 2d),
-            Vital.Stamina => (int) Math.Round(50d + (Data.Player[index].Level + GetPlayerStat(index, Stat.Spirit) / 2d) * 2d),
-            _ => 0
-        };
-    }
+            // Equivalent to Math.Floor(value / (double)divisor) but branchy int math
+            var q = value / divisor;
+            var r = value % divisor;
+            return (r != 0 && ((r ^ divisor) < 0)) ? (q - 1) : q;
+        }
 
-    public static int GetPlayerStat(int index, Stat stat)
-    {
-        int statValue = Data.Player[index].Stat[(int) stat];
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsValidPlayerIndex(int index) => (uint)index < (uint)Data.Player.Length;
 
-        for (var i = 0; i < EquipmentCount; i++)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsValidAccountIndex(int index) => (uint)index < (uint)Data.Account.Length;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsValidBankIndex(int index) => (uint)index < (uint)Data.Bank.Length;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsValidArrayIndex<T>(T[] arr, int idx) => arr != null && (uint)idx < (uint)arr.Length;
+
+        [Conditional("DEBUG")]
+        private static void AssertPlayer(int index)
         {
-            if (Data.Player[index].Equipment[i] >= 0 && Data.Item[Data.Player[index].Equipment[i]].AddStat[(int) stat] > 0)
+            Debug.Assert(IsValidPlayerIndex(index), $"Invalid player index {index}");
+        }
+
+        [Conditional("DEBUG")]
+        private static void AssertAccount(int index)
+        {
+            Debug.Assert(IsValidAccountIndex(index), $"Invalid account index {index}");
+        }
+
+        [Conditional("DEBUG")]
+        private static void AssertBank(int index)
+        {
+            Debug.Assert(IsValidBankIndex(index), $"Invalid bank index {index}");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool HasBit(byte mask, int bit) => ((mask & (1 << bit)) != 0);
+
+        // ------------------------------------
+        // Simple getters
+        // ------------------------------------
+
+        public static string GetAccountLogin(int index)
+        {
+            AssertAccount(index);
+            return IsValidAccountIndex(index) ? Data.Account[index].Login : string.Empty;
+        }
+
+        public static int GetPlayerExp(int index)
+        {
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? Data.Player[index].Exp : 0;
+        }
+
+        public static int GetPlayerRawStat(int index, Stat stat)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return 0;
+
+            var s = (int)stat;
+            var arr = Data.Player[index].Stat;
+            return IsValidArrayIndex(arr, s) ? arr[s] : 0;
+        }
+
+        public static string GetPlayerName(int index)
+        {
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? (Data.Player[index].Name ?? string.Empty) : string.Empty;
+        }
+
+        public static int GetPlayerInvValue(int index, int invslot)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return 0;
+
+            var inv = Data.Player[index].Inv;
+            return IsValidArrayIndex(inv, invslot) ? inv[invslot].Value : 0;
+        }
+
+        public static int GetPlayerPoints(int index)
+        {
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? Data.Player[index].Points : 0;
+        }
+
+        public static int GetPlayerVital(int index, Vital vital)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return 0;
+
+            var v = (int)vital;
+            var arr = Data.Player[index].Vital;
+            return IsValidArrayIndex(arr, v) ? arr[v] : 0;
+        }
+
+        public static int GetPlayerSprite(int index)
+        {
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? Data.Player[index].Sprite : 0;
+        }
+
+        public static int GetPlayerJob(int index)
+        {
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? Data.Player[index].Job : 0;
+        }
+
+        public static int GetPlayerMap(int index)
+        {
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? Data.Player[index].Map : 0;
+        }
+
+        public static int GetPlayerLevel(int index)
+        {
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? Data.Player[index].Level : 0;
+        }
+
+        public static int GetPlayerEquipment(int index, Equipment equipmentSlot)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return 0;
+
+            var e = Data.Player[index].Equipment;
+            var i = (int)equipmentSlot;
+            return IsValidArrayIndex(e, i) ? e[i] : 0;
+        }
+
+        public static int GetPlayerSkill(int index, int skillSlot)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return -1;
+
+            var skills = Data.Player[index].Skill;
+            return IsValidArrayIndex(skills, skillSlot) ? skills[skillSlot].Num : -1;
+        }
+
+        public static int GetPlayerSkillCd(int index, int skillSlot)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return 0;
+
+            var skills = Data.Player[index].Skill;
+            return IsValidArrayIndex(skills, skillSlot) ? skills[skillSlot].Cd : 0;
+        }
+
+        public static void SetPlayerLogin(int index, string login)
+        {
+            AssertAccount(index);
+            if (!IsValidAccountIndex(index)) return;
+            Data.Account[index].Login = login ?? string.Empty;
+        }
+
+        public static string GetPlayerPassword(int index)
+        {
+            AssertAccount(index);
+            return IsValidAccountIndex(index) ? (Data.Account[index].Password ?? string.Empty) : string.Empty;
+        }
+
+        public static void SetPlayerPassword(int index, string password)
+        {
+            AssertAccount(index);
+            if (!IsValidAccountIndex(index)) return;
+            Data.Account[index].Password = password ?? string.Empty;
+        }
+
+        // ------------------------------------
+        // Derived stats
+        // ------------------------------------
+
+        public static int GetPlayerMaxVital(int index, Vital vital)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return 0;
+
+            // Use doubles for formula then clamp down to int
+            int L() => GetPlayerLevel(index);
+            int S(Stat st) => GetPlayerStat(index, st);
+
+            return vital switch
             {
-                statValue += Data.Item[Data.Player[index].Equipment[i]].AddStat[(int) stat];
+                Vital.Health  => (int)Math.Round(100d + (L() + S(Stat.Vitality)     / 2d) * 2d),
+                Vital.Mana    => (int)Math.Round( 50d + (L() + S(Stat.Intelligence) / 2d) * 2d),
+                Vital.Stamina => (int)Math.Round( 50d + (L() + S(Stat.Spirit)       / 2d) * 2d),
+                _             => 0
+            };
+        }
+
+        public static int GetPlayerStat(int index, Stat stat)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return 0;
+
+            var sIndex = (int)stat;
+
+            var baseStats = Data.Player[index].Stat;
+            var statValue = IsValidArrayIndex(baseStats, sIndex) ? baseStats[sIndex] : 0;
+
+            // Add equipment bonuses (safe guarded)
+            var eq = Data.Player[index].Equipment;
+            if (eq == null) return statValue;
+
+            for (var i = 0; i < Math.Min(EquipmentCount, eq.Length); i++)
+            {
+                var itemId = eq[i];
+                if (itemId < 0) continue;
+
+                // check item bounds
+                if (!IsValidArrayIndex(Data.Item, itemId)) continue;
+
+                var add = Data.Item[itemId].AddStat;
+                if (!IsValidArrayIndex(add, sIndex)) continue;
+
+                statValue += add[sIndex];
             }
+
+            return statValue;
         }
 
-        return statValue;
-    }
+        // ------------------------------------
+        // Accessors / position / flags
+        // ------------------------------------
 
-    public static byte GetPlayerAccess(int index)
-    {
-        return Data.Player[index].Access;
-    }
-
-    public static int GetPlayerX(int index)
-    {
-        return (int) Math.Floor((double) Data.Player[index].X / 32);
-    }
-
-    public static int GetPlayerY(int index)
-    {
-        return (int) Math.Floor((double) Data.Player[index].Y / 32);
-    }
-
-    public static int GetPlayerRawX(int index)
-    {
-        return Data.Player[index].X;
-    }
-
-    public static int GetPlayerRawY(int index)
-    {
-        return Data.Player[index].Y;
-    }
-
-    public static byte GetPlayerDir(int index)
-    {
-        return Data.Player[index].Dir;
-    }
-
-    public static bool GetPlayerPk(int index)
-    {
-        return Data.Player[index].Pk;
-    }
-
-    public static void SetPlayerVital(int index, Vital vital, int value)
-    {
-        Data.Player[index].Vital[(int) vital] = value;
-
-        if (GetPlayerVital(index, vital) > GetPlayerMaxVital(index, vital))
+        public static byte GetPlayerAccess(int index)
         {
-            Data.Player[index].Vital[(int) vital] = GetPlayerMaxVital(index, vital);
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? Data.Player[index].Access : (byte)0;
         }
 
-        if (GetPlayerVital(index, vital) < 0)
+        public static int GetPlayerX(int index)
         {
-            Data.Player[index].Vital[(int) vital] = 0;
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? FloorDiv(Data.Player[index].X, TileSize) : 0;
         }
-    }
 
-    public static bool IsDirBlocked(byte blockvar, Direction dir)
-    {
-        return dir switch
+        public static int GetPlayerY(int index)
         {
-            Direction.UpRight =>
-                (blockvar & (long) Math.Round(Math.Pow(2d, (double) Direction.Up))) != 0 ||
-                (blockvar & (long) Math.Round(Math.Pow(2d, (double) Direction.Right))) != 0,
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? FloorDiv(Data.Player[index].Y, TileSize) : 0;
+        }
 
-            Direction.UpLeft =>
-                (blockvar & (long) Math.Round(Math.Pow(2d, (double) Direction.Up))) != 0 ||
-                (blockvar & (long) Math.Round(Math.Pow(2d, (double) Direction.Left))) != 0,
-
-            Direction.DownRight =>
-                (blockvar & (long) Math.Round(Math.Pow(2d, (double) Direction.Down))) != 0 ||
-                (blockvar & (long) Math.Round(Math.Pow(2d, (double) Direction.Right))) != 0,
-
-            Direction.DownLeft =>
-                (blockvar & (long) Math.Round(Math.Pow(2d, (double) Direction.Down))) != 0 ||
-                (blockvar & (long) Math.Round(Math.Pow(2d, (double) Direction.Left))) != 0,
-
-            _ => (blockvar & (long) Math.Round(Math.Pow(2d, (byte) dir))) != 0
-        };
-    }
-
-
-    public static int GetPlayerNextLevel(int index)
-    {
-        return (int) Math.Round(50d / 3d * (Math.Pow(GetPlayerLevel(index) + 1, 3d) - 6d * Math.Pow(GetPlayerLevel(index) + 1, 2d) + 17 * (GetPlayerLevel(index) + 1) - 12d));
-    }
-
-    public static void SetPlayerGatherSkillLvl(int index, int skillSlot, int lvl)
-    {
-        Data.Player[index].GatherSkills[skillSlot].SkillLevel = lvl;
-    }
-
-    public static void SetPlayerGatherSkillExp(int index, int skillSlot, int exp)
-    {
-        Data.Player[index].GatherSkills[skillSlot].SkillCurExp = exp;
-    }
-
-    public static void SetPlayerGatherSkillMaxExp(int index, int skillSlot, int maxExp)
-    {
-        Data.Player[index].GatherSkills[skillSlot].SkillNextLvlExp = maxExp;
-    }
-
-    public static string GetResourceSkillName(ResourceSkill skillNum)
-    {
-        return skillNum switch
+        public static int GetPlayerRawX(int index)
         {
-            ResourceSkill.Herbalism => "Herbalism",
-            ResourceSkill.Woodcutting => "Woodcutting",
-            ResourceSkill.Mining => "Mining",
-            ResourceSkill.Fishing => "Fishing",
-            _ => string.Empty
-        };
-    }
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? Data.Player[index].X : 0;
+        }
 
-    public static int GetSkillNextLevel(int index, int skillSlot)
-    {
-        return (int) Math.Round(50d / 3d * (Math.Pow(GetPlayerGatherSkillLvl(index, skillSlot) + 1, 3d) - 6d * Math.Pow(GetPlayerGatherSkillLvl(index, skillSlot) + 1, 2d) + 17 * (GetPlayerGatherSkillLvl(index, skillSlot) + 1) - 12d));
-    }
-
-    public static bool IsPlaying(int index)
-    {
-        return GetPlayerName(index).Length > 0;
-    }
-
-    public static int GetPlayerGatherSkillLvl(int index, int skillSlot)
-    {
-        return Data.Player[index].GatherSkills[skillSlot].SkillLevel;
-    }
-
-    public static int GetPlayerGatherSkillExp(int index, int skillSlot)
-    {
-        return Data.Player[index].GatherSkills[skillSlot].SkillCurExp;
-    }
-
-    public static int GetPlayerGatherSkillMaxExp(int index, int skillSlot)
-    {
-        return Data.Player[index].GatherSkills[skillSlot].SkillNextLvlExp;
-    }
-
-    public static void SetPlayerMap(int index, int mapNum)
-    {
-        Data.Player[index].Map = mapNum;
-    }
-
-    public static int GetPlayerInv(int index, int invslot)
-    {
-        return Data.Player[index].Inv[invslot].Num;
-    }
-
-    public static void SetPlayerName(int index, string name)
-    {
-        Data.Player[index].Name = name;
-    }
-
-    public static void SetPlayerJob(int index, int jobNum)
-    {
-        Data.Player[index].Job = (byte) jobNum;
-    }
-
-    public static void SetPlayerPoints(int index, int points)
-    {
-        Data.Player[index].Points = (byte) points;
-    }
-
-    public static void SetPlayerStat(int index, Stat stat, int value)
-    {
-        Data.Player[index].Stat[(int) stat] = (byte) value;
-    }
-
-    public static void SetPlayerInv(int index, int invSlot, int itemNum)
-    {
-        Data.Player[index].Inv[invSlot].Num = itemNum;
-    }
-
-    public static void SetPlayerInvValue(int index, int invslot, int itemValue)
-    {
-        Data.Player[index].Inv[invslot].Value = itemValue;
-    }
-
-    public static void SetPlayerAccess(int index, byte access)
-    {
-        Data.Player[index].Access = access;
-    }
-
-    public static void SetPlayerPk(int index, bool pk)
-    {
-        Data.Player[index].Pk = pk;
-    }
-
-    public static void SetPlayerX(int index, int x)
-    {
-        Data.Player[index].X = x;
-    }
-
-    public static void SetPlayerY(int index, int y)
-    {
-        Data.Player[index].Y = y;
-    }
-
-    public static void SetPlayerSprite(int index, int sprite)
-    {
-        Data.Player[index].Sprite = sprite;
-    }
-
-    public static void SetPlayerExp(int index, int exp)
-    {
-        Data.Player[index].Exp = exp;
-    }
-
-    public static void SetPlayerLevel(int index, int level)
-    {
-        Data.Player[index].Level = (byte) level;
-    }
-
-    public static void SetPlayerDir(int index, int dir)
-    {
-        Data.Player[index].Dir = (byte) dir;
-    }
-
-    public static void SetPlayerEquipment(int index, int itemNum, Equipment equipmentSlot)
-    {
-        Data.Player[index].Equipment[(int) equipmentSlot] = itemNum;
-    }
-
-    public static string IsEditorLocked(int index, EditorType id)
-    {
-        for (int i = 0; i < Constant.MaxPlayers; i++)
+        public static int GetPlayerRawY(int index)
         {
-            if (IsPlaying(i))
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? Data.Player[index].Y : 0;
+        }
+
+        public static byte GetPlayerDir(int index)
+        {
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) ? Data.Player[index].Dir : (byte)0;
+        }
+
+        public static bool GetPlayerPk(int index)
+        {
+            AssertPlayer(index);
+            return IsValidPlayerIndex(index) && Data.Player[index].Pk;
+        }
+
+        public static void SetPlayerVital(int index, Vital vital, int value)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+
+            var vidx = (int)vital;
+            var arr = Data.Player[index].Vital;
+            if (!IsValidArrayIndex(arr, vidx)) return;
+
+            arr[vidx] = value;
+
+            var max = GetPlayerMaxVital(index, vital);
+            if (arr[vidx] > max) arr[vidx] = max;
+            if (arr[vidx] < 0)   arr[vidx] = 0;
+        }
+
+        /// <summary>Block‑map bit test with diagonal logic. Replaced slow Math.Pow with bit ops.</summary>
+        public static bool IsDirBlocked(byte blockvar, Direction dir)
+        {
+            int m = blockvar; // widen to int for bit math
+
+            return dir switch
             {
-                if (i != index)
+                Direction.UpRight  => HasBit((byte)m, (int)Direction.Up)   || HasBit((byte)m, (int)Direction.Right),
+                Direction.UpLeft   => HasBit((byte)m, (int)Direction.Up)   || HasBit((byte)m, (int)Direction.Left),
+                Direction.DownRight=> HasBit((byte)m, (int)Direction.Down) || HasBit((byte)m, (int)Direction.Right),
+                Direction.DownLeft => HasBit((byte)m, (int)Direction.Down) || HasBit((byte)m, (int)Direction.Left),
+                _                  => HasBit((byte)m, (int)dir)
+            };
+        }
+
+        // ------------------------------------
+        // XP curves
+        // ------------------------------------
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int NextLevelExpFor(int level)
+        {
+            // E(n+1) = (50/3) * ( (n+1)^3 - 6(n+1)^2 + 17(n+1) - 12 )
+            var n1 = level + 1;
+            var d = (50d / 3d) * (Math.Pow(n1, 3d) - 6d * Math.Pow(n1, 2d) + 17d * n1 - 12d);
+            return (int)Math.Round(d);
+        }
+
+        public static int GetPlayerNextLevel(int index)
+        {
+            return NextLevelExpFor(GetPlayerLevel(index));
+        }
+
+        // ------------------------------------
+        // Gathering skills
+        // ------------------------------------
+
+        public static void SetPlayerGatherSkillLvl(int index, int skillSlot, int lvl)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+
+            var gs = Data.Player[index].GatherSkills;
+            if (!IsValidArrayIndex(gs, skillSlot)) return;
+
+            gs[skillSlot].SkillLevel = lvl;
+        }
+
+        public static void SetPlayerGatherSkillExp(int index, int skillSlot, int exp)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+
+            var gs = Data.Player[index].GatherSkills;
+            if (!IsValidArrayIndex(gs, skillSlot)) return;
+
+            gs[skillSlot].SkillCurExp = exp;
+        }
+
+        public static void SetPlayerGatherSkillMaxExp(int index, int skillSlot, int maxExp)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+
+            var gs = Data.Player[index].GatherSkills;
+            if (!IsValidArrayIndex(gs, skillSlot)) return;
+
+            gs[skillSlot].SkillNextLvlExp = maxExp;
+        }
+
+        public static string GetResourceSkillName(ResourceSkill skillNum)
+        {
+            return skillNum switch
+            {
+                ResourceSkill.Herbalism   => "Herbalism",
+                ResourceSkill.Woodcutting => "Woodcutting",
+                ResourceSkill.Mining      => "Mining",
+                ResourceSkill.Fishing     => "Fishing",
+                _                         => string.Empty
+            };
+        }
+
+        public static int GetSkillNextLevel(int index, int skillSlot)
+        {
+            return NextLevelExpFor(GetPlayerGatherSkillLvl(index, skillSlot));
+        }
+
+        public static bool IsPlaying(int index)
+        {
+            return GetPlayerName(index).Length > 0;
+        }
+
+        public static int GetPlayerGatherSkillLvl(int index, int skillSlot)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return 0;
+
+            var gs = Data.Player[index].GatherSkills;
+            return IsValidArrayIndex(gs, skillSlot) ? gs[skillSlot].SkillLevel : 0;
+        }
+
+        public static int GetPlayerGatherSkillExp(int index, int skillSlot)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return 0;
+
+            var gs = Data.Player[index].GatherSkills;
+            return IsValidArrayIndex(gs, skillSlot) ? gs[skillSlot].SkillCurExp : 0;
+        }
+
+        public static int GetPlayerGatherSkillMaxExp(int index, int skillSlot)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return 0;
+
+            var gs = Data.Player[index].GatherSkills;
+            return IsValidArrayIndex(gs, skillSlot) ? gs[skillSlot].SkillNextLvlExp : 0;
+        }
+
+        // ------------------------------------
+        // Map / inventory / identity
+        // ------------------------------------
+
+        public static void SetPlayerMap(int index, int mapNum)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+            Data.Player[index].Map = mapNum;
+        }
+
+        public static int GetPlayerInv(int index, int invslot)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return -1;
+
+            var inv = Data.Player[index].Inv;
+            return IsValidArrayIndex(inv, invslot) ? inv[invslot].Num : -1;
+        }
+
+        public static void SetPlayerName(int index, string name)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+            Data.Player[index].Name = name ?? string.Empty;
+        }
+
+        public static void SetPlayerJob(int index, int jobNum)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+            Data.Player[index].Job = Clamp(jobNum, byte.MinValue, byte.MaxValue);
+        }
+
+        public static void SetPlayerPoints(int index, int points)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+            Data.Player[index].Points = Clamp(points, byte.MinValue, byte.MaxValue);
+        }
+
+        public static void SetPlayerStat(int index, Stat stat, int value)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+
+            var s = (int)stat;
+            var arr = Data.Player[index].Stat;
+            if (!IsValidArrayIndex(arr, s)) return;
+
+            arr[s] = Clamp(value, byte.MinValue, byte.MaxValue);
+        }
+
+        public static void SetPlayerInv(int index, int invSlot, int itemNum)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+
+            var inv = Data.Player[index].Inv;
+            if (!IsValidArrayIndex(inv, invSlot)) return;
+
+            inv[invSlot].Num = itemNum;
+        }
+
+        public static void SetPlayerInvValue(int index, int invslot, int itemValue)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+
+            var inv = Data.Player[index].Inv;
+            if (!IsValidArrayIndex(inv, invslot)) return;
+
+            inv[invslot].Value = itemValue;
+        }
+
+        public static void SetPlayerAccess(int index, byte access)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+            Data.Player[index].Access = access;
+        }
+
+        public static void SetPlayerPk(int index, bool pk)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+            Data.Player[index].Pk = pk;
+        }
+
+        public static void SetPlayerX(int index, int x)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+            Data.Player[index].X = x;
+        }
+
+        public static void SetPlayerY(int index, int y)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+            Data.Player[index].Y = y;
+        }
+
+        public static void SetPlayerSprite(int index, int sprite)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+            Data.Player[index].Sprite = sprite;
+        }
+
+        public static void SetPlayerExp(int index, int exp)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+            Data.Player[index].Exp = exp;
+        }
+
+        public static void SetPlayerLevel(int index, int level)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+            Data.Player[index].Level = Clamp(level, byte.MinValue, byte.MaxValue);
+        }
+
+        public static void SetPlayerDir(int index, int dir)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+            Data.Player[index].Dir = ClampToByte(dir);
+        }
+
+        public static void SetPlayerEquipment(int index, int itemNum, Equipment equipmentSlot)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+
+            var e = Data.Player[index].Equipment;
+            var i = (int)equipmentSlot;
+            if (!IsValidArrayIndex(e, i)) return;
+
+            e[i] = itemNum;
+        }
+
+        // ------------------------------------
+        // Editor / skills management
+        // ------------------------------------
+
+        public static string IsEditorLocked(int index, EditorType id)
+        {
+            var myName = GetPlayerName(index);
+
+            for (int i = 0; i < Constant.MaxPlayers; i++)
+            {
+                if (i == index) continue;
+                if (!IsPlaying(i)) continue;
+
+                if (Data.TempPlayer[i].Editor == id)
                 {
-                    if (Data.TempPlayer[i].Editor == id)
-                    {
-                        if (GetPlayerName(i) != GetPlayerName(index))
-                            return GetPlayerName(i);
-                    }
+                    var name = GetPlayerName(i);
+                    if (!name.Equals(myName, StringComparison.Ordinal))
+                        return name;
                 }
             }
+
+            return string.Empty;
         }
 
-        return "";
-    }
-
-    public static int FindOpenSkill(int index)
-    {
-        for (var slot = 0; slot < Constant.MaxPlayerSkills; slot++)
+        public static int FindOpenSkill(int index)
         {
-            if (GetPlayerSkill(index, slot) == -1)
+            for (var slot = 0; slot < Constant.MaxPlayerSkills; slot++)
             {
-                return slot;
+                if (GetPlayerSkill(index, slot) == -1)
+                    return slot;
             }
+
+            return -1;
         }
 
-        return -1;
-    }
-
-    public static void SetPlayerSkillCd(int index, int skillSlot, int value)
-    {
-        Data.Player[index].Skill[skillSlot].Cd = value;
-    }
-
-    public static bool HasSkill(int index, double skillNum)
-    {
-        for (var slot = 0; slot < Constant.MaxPlayerSkills; slot++)
+        public static void SetPlayerSkillCd(int index, int skillSlot, int value)
         {
-            if (GetPlayerSkill(index, slot) == skillNum)
-            {
-                return true;
-            }
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
+
+            var skills = Data.Player[index].Skill;
+            if (!IsValidArrayIndex(skills, skillSlot)) return;
+
+            skills[skillSlot].Cd = value;
         }
 
-        return false;
-    }
+        // Kept signature (double), but compare as int to avoid floating issues.
+        public static bool HasSkill(int index, double skillNum)
+        {
+            var target = (int)Math.Round(skillNum);
+            for (var slot = 0; slot < Constant.MaxPlayerSkills; slot++)
+            {
+                if (GetPlayerSkill(index, slot) == target)
+                    return true;
+            }
 
-    public static void SetPlayerSkill(int index, int skillslot, int skillNum)
-    {
-        Data.Player[index].Skill[skillslot].Num = skillNum;
-    }
+            return false;
+        }
 
-    public static int GetBank(int index, int bankslot)
-    {
-        return Data.Bank[index].Item[bankslot].Num;
-    }
+        public static void SetPlayerSkill(int index, int skillslot, int skillNum)
+        {
+            AssertPlayer(index);
+            if (!IsValidPlayerIndex(index)) return;
 
-    public static void SetBank(int index, byte bankSlot, int itemNum)
-    {
-        Data.Bank[index].Item[bankSlot].Num = itemNum;
-    }
+            var skills = Data.Player[index].Skill;
+            if (!IsValidArrayIndex(skills, skillslot)) return;
 
-    public static int GetBankValue(int index, int bankSlot)
-    {
-        return Data.Bank[index].Item[bankSlot].Value;
-    }
+            skills[skillslot].Num = skillNum;
+        }
 
-    public static void SetBankValue(int index, byte bankSlot, int itemValue)
-    {
-        Data.Bank[index].Item[bankSlot].Value = itemValue;
+        // ------------------------------------
+        // Bank
+        // ------------------------------------
+
+        public static int GetBank(int index, int bankslot)
+        {
+            AssertBank(index);
+            if (!IsValidBankIndex(index)) return -1;
+
+            var items = Data.Bank[index].Item;
+            return IsValidArrayIndex(items, bankslot) ? items[bankslot].Num : -1;
+        }
+
+        public static void SetBank(int index, byte bankSlot, int itemNum)
+        {
+            AssertBank(index);
+            if (!IsValidBankIndex(index)) return;
+
+            var items = Data.Bank[index].Item;
+            if (!IsValidArrayIndex(items, bankSlot)) return;
+
+            items[bankSlot].Num = itemNum;
+        }
+
+        public static int GetBankValue(int index, int bankSlot)
+        {
+            AssertBank(index);
+            if (!IsValidBankIndex(index)) return 0;
+
+            var items = Data.Bank[index].Item;
+            return IsValidArrayIndex(items, bankSlot) ? items[bankSlot].Value : 0;
+        }
+
+        public static void SetBankValue(int index, byte bankSlot, int itemValue)
+        {
+            AssertBank(index);
+            if (!IsValidBankIndex(index)) return;
+
+            var items = Data.Bank[index].Item;
+            if (!IsValidArrayIndex(items, bankSlot)) return;
+
+            items[bankSlot].Value = itemValue;
+        }
     }
 }


### PR DESCRIPTION
Bit‑math fix & speedup (IsDirBlocked)
Replaced Math.Pow(2, …) and long casts with bit operations (1 << bit). It’s vastly faster, avoids double→integer rounding, and eliminates precision pitfalls.

Robust bounds checks (no more sneaky IndexOutOfRange) All getters/setters now validate indices (player, account, bank, arrays like Inv, Stat, Vital, Skill, Equipment) and early‑out safely. In DEBUG builds we also Debug.Assert to catch logic bugs during development.

Consistent clamping for byte fields
For Level, Points, Job, Dir, Stat[] setters, values are clamped to byte range instead of raw casts, preventing overflow wrap‑around.

Floor division helpers for map tiles
GetPlayerX/Y previously used Math.Floor(double); I added FloorDiv(int,int) to get correct tile coordinates for negative positions without a double conversion.

XP curve deduplication
Centralized the next‑level XP formula in NextLevelExpFor(int level) and reused it in GetPlayerNextLevel and GetSkillNextLevel to keep the curve consistent.

Safer null/length checks on nested arrays
Equipment stat aggregation now confirms the item id is valid and the AddStat array has the index, avoiding crashes if data isn’t perfectly aligned.

String safety & culture predictability
IsEditorLocked compares names using StringComparison.Ordinal and returns string.Empty instead of "" for clarity.

Tiny perf wins

Cached EquipmentCount with Enum.GetValues<Equipment>().Length (cheaper than GetNames()).

Inlined small helpers with [MethodImpl(AggressiveInlining)].

Reduced redundant indexing (e.g., local array refs before loops).

Non‑breaking
All original method names and signatures are preserved, so this is a drop‑in. The only behavior changes are safer (guards/clamps) and faster (bit ops / reduced allocation / fewer conversions).