### PR TITLE
Create TokenBucket.cs

### DIFF
--- a/Source/Server/Infrastructure/RateLimiting/TokenBucket.cs
+++ b/Source/Server/Infrastructure/RateLimiting/TokenBucket.cs
@@ -1,0 +1,50 @@
+// Server/Infrastructure/RateLimiting/TokenBucket.cs
+using System;
+using System.Diagnostics;
+
+namespace XtremeWorlds.Infrastructure.RateLimiting
+{
+    /// <summary>
+    /// Simple token-bucket limiter: capacity tokens max; refills "perSecond".
+    /// TryConsume(n) succeeds only if at least n tokens are available.
+    /// </summary>
+    public sealed class TokenBucket
+    {
+        private readonly double _capacity;
+        private readonly double _perSecond;
+        private double _tokens;
+        private long _lastTicks;
+
+        public TokenBucket(int capacity, int refillPerSecond)
+        {
+            if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity));
+            if (refillPerSecond < 0) throw new ArgumentOutOfRangeException(nameof(refillPerSecond));
+
+            _capacity = capacity;
+            _perSecond = refillPerSecond;
+            _tokens = capacity;
+            _lastTicks = Stopwatch.GetTimestamp();
+        }
+
+        /// <summary>Returns true if the requested amount was consumed.</summary>
+        public bool TryConsume(int amount = 1)
+        {
+            if (amount <= 0) return true;
+
+            var now = Stopwatch.GetTimestamp();
+            var dt = (now - _lastTicks) / (double)Stopwatch.Frequency;
+            _lastTicks = now;
+
+            // Refill
+            _tokens = Math.Min(_capacity, _tokens + dt * _perSecond);
+
+            if (_tokens >= amount)
+            {
+                _tokens -= amount;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Idea: Add a small, dependency‑free per‑client rate limiter to drop/slow spammy packets (chat/move/join‑map/etc.). It’s a low‑risk, copy‑paste improvement that helps stability and fairness on busy servers and protects hot code paths from bursty input.